### PR TITLE
Remove tables from navigation bar and expired link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,23 +1,21 @@
 <!-- header html fragment -->
-<div class="navbar navbar-fixed-top">
+<nav class="navbar navbar-fixed-top">
 	<div class="navbar-inner"> 
 		<div class="container"> 
 			<div id="headline" class="brand puppy-logo">Puppy Linux <!-- Header and Navigation -> Home, News, etc--> 
 				<div id="boxbar">
-					<table>
-						<tr>
-						<th class="nav"><a href="index.html" title="Home"><img class="nav-icons" src="c/home.png" alt="Home"></a></th>
-						<th class="nav"><a href="http://blog.puppylinux.com/" title="Puppy Linux Blog"><img class="nav-icons" src="c/news.png" alt="Blog"></a></th>
-						<th class="nav"><a href="index.html#download" title="Download"><img class="nav-icons" src="c/dld.png" alt="Download"></a></th>
-						<th class="nav"><a href="http://murga-linux.com/puppy" title="Discussion Forum"><img class="nav-icons" src="c/forum.png" alt="Forum"></a></th>
-						<th class="nav"><a href="http://www.puppylinux.org/wikka/HomePage" title="Puppy Linux wiki"><img class="nav-icons" src="c/wiki.png" alt="Wiki"></a></th>
-						</tr>
-					</table>
+					<ul>
+						<li class="nav"><a href="index.html" title="Home"><img class="nav-icons" src="c/home.png" alt="Home"></a></li>
+						<li class="nav"><a href="http://blog.puppylinux.com/" title="Puppy Linux Blog"><img class="nav-icons" src="c/news.png" alt="Blog"></a></li>
+						<li class="nav"><a href="index.html#download" title="Download"><img class="nav-icons" src="c/dld.png" alt="Download"></a></li>
+						<li class="nav"><a href="http://murga-linux.com/puppy" title="Discussion Forum"><img class="nav-icons" src="c/forum.png" alt="Forum"></a></li>
+						<li class="nav"><a href="http://www.puppylinux.org/wikka/HomePage" title="Puppy Linux wiki"><img class="nav-icons" src="c/wiki.png" alt="Wiki"></a></li>
+					</ul>
 				</div>
 			</div> 
 		</div>
 	</div>
-</div>
+</nav>
 <div id="nos">
 	<noscript class="ns">The Puppy Linux Site is best viewed with JavaScript enabled</noscript>
 </div>

--- a/c/puppy.css
+++ b/c/puppy.css
@@ -11,19 +11,26 @@
 	height: 32px;
 	margin-left: 1em;
 }
-th.nav {
+#boxbar ul {
+	list-style: none;
+}
+#boxbar ul li {
+	float: left;
+}
+li.nav {
     width: 84px;
 }
-th.nav:hover {
+li.nav:hover {
     background: #f5f5f5;
 }
-th.nav a {
+li.nav a {
     display:block;
     text-decoration:none;
 }
 .nav-icons {
 	height: 24px;
 	width: 24px;
+	margin-left: 30px;
 }
 noscript p {
 	color:#FF518E

--- a/download.md
+++ b/download.md
@@ -11,7 +11,6 @@ title: Puppy Linux Downloads
 |Slacko          |slackware-compatible Official Puppy (32 and 64bit)|[Slacko Website][sla]       |
 |Tahrpup         |UbuntuLTS-compatible Official Puppy               |[Tahrpup Forum Page][t32]   |
 |Tahrpup64       |64 bit UbuntuLTS-compatible Official Puppy        |[Tahrpup64 Forum Page][t64] |
-|Librepup        |A puppy without any non-free components (FOSS)    |[Librepup Website][lib]     |
 |LxPupSc         |Puppy with the LXDE desktop                       |[LxPupSc Forum Page][lxp]   |
 |Development     |Slacko Puppy development version                 |[Slacko Dev Forum Page][sde]|
 |Development     |Xenial Puppy development version                 |[Xenial Dev Forum Page][xen]|
@@ -20,7 +19,6 @@ title: Puppy Linux Downloads
 [sla]: http://slacko.eezy.xyz
 [t32]: http://murga-linux.com/puppy/viewtopic.php?t=96178
 [t64]: http://murga-linux.com/puppy/viewtopic.php?t=96748
-[lib]: http://librepup.info/
 [lxp]: http://murga-linux.com/puppy/viewtopic.php?t=101527
 [sde]: http://murga-linux.com/puppy/viewtopic.php?t=108017
 [xen]: http://murga-linux.com/puppy/viewtopic.php?t=106479


### PR DESCRIPTION
Removed tables from navigation bar. This helps in better
readability by search engines.

(Kept the design same before , hopefully this will not increase the complexity for other contributors.  :confused:)
